### PR TITLE
Update reciprocalspaceship links to point to rs-station org

### DIFF
--- a/CARELESS_ZERO.md
+++ b/CARELESS_ZERO.md
@@ -3,7 +3,7 @@
 The implementation of variational scaling inside of Careless is a tad convoluted, because it is designed for flexibility. 
 For those users that want to know more about how Careless actually works, but don't care to sift through the actual source, I've provided this super minimalist [implementation](careless_zero/careless_zero.py) in 100 lines of python. 
 
-The script merges X-ray data using [reciprocalspaceship](https://github.com/hekstra-lab/reciprocalspaceship) for data i/o and [tensorflow_probability](https://www.tensorflow.org/probability) for probabilistic programming.
+The script merges X-ray data using [reciprocalspaceship](https://github.com/rs-station/reciprocalspaceship) for data i/o and [tensorflow_probability](https://www.tensorflow.org/probability) for probabilistic programming.
 `careless_zero.py` inplements the default Careless model and uses it to merge the lysozyme SAD [data set](HEWLSSAD.md).
 To run the script, first enter the careless zero directory,
 

--- a/PYPTRX.md
+++ b/PYPTRX.md
@@ -19,7 +19,7 @@ You will see the following items:
  - reference_data/off.pdb (Atomic model of the ground state)
 
 Because we will have to supply metadata from the mtz files, let's first have  look at what is inside them.
-This can be easily done with a command line script supplied by [ReciprocalSpaceship](https://hekstra-lab.github.io/reciprocalspaceship/) which will have been installed when you installed `Careless`. Type `rs.mtzdump off.mtz`; you should something like the following output. 
+This can be easily done with a command line script supplied by [ReciprocalSpaceship](https://rs-station.github.io/reciprocalspaceship/) which will have been installed when you installed `Careless`. Type `rs.mtzdump off.mtz`; you should something like the following output. 
 
 ```
 Spacegroup: P63

--- a/XFEL.md
+++ b/XFEL.md
@@ -6,7 +6,7 @@ Because the original data set is very large, this example deals with a single ru
 The unmerged reflections, stored in `careless-examples/thermolysin_xfel/unmerged.mtz` were prepared with a custom `cctbx` [script](https://github.com/rs-station/careless/blob/master/scripts/stills2mtz). 
 
 
-Enter the thermolysin directory and use [reciprocalspaceship](https://github.com/hekstra-lab/reciprocalspaceship) to explore the contents of this mtz file. 
+Enter the thermolysin directory and use [reciprocalspaceship](https://github.com/rs-station/reciprocalspaceship) to explore the contents of this mtz file. 
 
 ```bash
 cd careless-examples/thermolysin_xfel


### PR DESCRIPTION
This is low stakes because github auto-redirects these links, but I figured there was no harm in updating the hyperlinks